### PR TITLE
Fix logsumexp import

### DIFF
--- a/minimc/distributions.py
+++ b/minimc/distributions.py
@@ -1,5 +1,5 @@
 import autograd.numpy as np
-from autograd.scipy.misc import logsumexp
+from autograd.scipy.special import logsumexp
 
 __all__ = ["neg_log_normal", "neg_log_mvnormal", "mixture", "neg_log_funnel"]
 


### PR DESCRIPTION
Import of minimc is failing with the most recent version of autograd. The definition of logsumexp has been moved to autograd.scipy.special. Thanks!